### PR TITLE
Add upper bound for cmake install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setuptools.setup(
     # scripts=(glob.glob("scripts/prepare_TLG_fst/**/*.py") +
     #          glob.glob("scripts/prepare_TLG_fst/**/*.sh")),
     include_package_data=True,
-    install_requires=["sentencepiece", "cmake>=3.18", "ninja",],
+    install_requires=["sentencepiece", "cmake>=3.18,<3.25", "ninja",],
     extras_require={
         'testing': [
             "kaldi-io",


### PR DESCRIPTION
Fixes:

#39 15.28       CMake Error at /usr/local/lib/python3.8/dist-packages/cmake/data/share/cmake-3.25/Modules/FindCUDAToolkit.cmake:1063 (target_link_libraries):
#39 15.28         Cannot specify link libraries for target "CUDA::nvptxcompiler_static" which
#39 15.28         is not built by this project.