### PR TITLE
Fix stall when pynini is imported before this library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,12 @@ if(NOT openfst_POPULATED)
     )
   target_include_directories(riva_asrlib_openfst SYSTEM PUBLIC ${openfst_SOURCE_DIR}/src/include/)
   set_target_properties(riva_asrlib_openfst PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-  target_compile_options(riva_asrlib_openfst PUBLIC -Wno-unused-local-typedefs -Wno-sign-compare -Wno-unused-variable)
+  target_compile_options(riva_asrlib_openfst PUBLIC -Wno-unused-local-typedefs -Wno-sign-compare -Wno-unused-variable -fno-gnu-unique)
 
   add_library(fst-types OBJECT "${openfst_SOURCE_DIR}/src/lib/fst-types.cc")
   target_include_directories(fst-types SYSTEM PUBLIC ${openfst_SOURCE_DIR}/src/include/)
   set_target_properties(fst-types PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-  target_compile_options(fst-types PUBLIC -Wno-unused-local-typedefs -Wno-sign-compare -Wno-unused-variable)
-
+  target_compile_options(fst-types PUBLIC -Wno-unused-local-typedefs -Wno-sign-compare -Wno-unused-variable -fno-gnu-unique)
 
   add_library(fstscript_base
     "${openfst_SOURCE_DIR}/src/script/arciterator-class.cc"

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class BuildExtension(build_ext):
 setuptools.setup(
     python_requires='>=3.7',
     name='riva-asrlib-decoder',
-    version='0.4.2',
+    version='0.4.3',
     author='NVIDIA',
     author_email='dgalvez@nvidia.com',
     keywords='ASR, CUDA, WFST, Decoder',

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class BuildExtension(build_ext):
 setuptools.setup(
     python_requires='>=3.7',
     name='riva-asrlib-decoder',
-    version='0.4.1',
+    version='0.4.2',
     author='NVIDIA',
     author_email='dgalvez@nvidia.com',
     keywords='ASR, CUDA, WFST, Decoder',

--- a/src/riva/asrlib/decoder/test_graph_construction.py
+++ b/src/riva/asrlib/decoder/test_graph_construction.py
@@ -52,7 +52,7 @@ from riva.asrlib.decoder.python_decoder import BatchedMappedDecoderCuda, Batched
 
 from nemo.collections.asr.metrics.wer import word_error_rate
 
-ERROR_MARGIN = 0.0002
+ERROR_MARGIN = 0.0003
 
 # os.environ["TORCH_CUDNN_V8_API_ENABLED"]="1"
 


### PR DESCRIPTION
Previously, doing this:

import pynini
import riva.asrlib.decoder

would end in a stall. This was because the FlagRegister template class had a static variable Mutex, that ended up being shared by default in the global symbol namespace. Because the openfst versions are different between the two libraries (I think pynini's openfst 1.8.2 uses absl::Mutex), the mutex layouts are different, probably causing the stall.

We don't want the symbols to be shared in this case, so we disable unique symbols via "-fno-gnu-unique".